### PR TITLE
Add a checkbox to preferences to enable or disable  suggestion sounds.

### DIFF
--- a/addon/globalPlugins/wintenObjs/__init__.py
+++ b/addon/globalPlugins/wintenObjs/__init__.py
@@ -71,7 +71,8 @@ class SearchField(UIA):
 			self.event_suggestionsClosed()
 
 	def event_suggestionsOpened(self):
-		nvwave.playWaveFile(os.path.join(os.path.dirname(__file__), "suggestion.wav"))
+		if config.conf["wintenApps"]["suggestionSounds"]:
+			nvwave.playWaveFile(os.path.join(os.path.dirname(__file__), "suggestion.wav"))
 		# Translators: Announced in braille when suggestions appear.
 		braille.handler.message(_("suggestions"))
 		# Announce number of items found (except in Start search box where the suggestions are selected as user types).
@@ -95,7 +96,8 @@ class SearchField(UIA):
 				ui.message(obj.description)
 				return
 			obj = obj.next
-		nvwave.playWaveFile(os.path.join(os.path.dirname(__file__), "suggestion1.wav"))
+		if config.conf["wintenApps"]["suggestionSounds"]:
+			nvwave.playWaveFile(os.path.join(os.path.dirname(__file__), "suggestion1.wav"))
 
 
 # General suggestions item handler

--- a/addon/globalPlugins/wintenObjs/w10config.py
+++ b/addon/globalPlugins/wintenObjs/w10config.py
@@ -28,6 +28,7 @@ confspec = {
 	"updateChannel": "string(default=dev)",
 	"updateCheckTime": "integer(default=0)",
 	"updateCheckTimeInterval": "integer(min=0, max=30, default=1)",
+	"suggestionSounds": "boolean(default=true)",
 }
 config.conf.spec["wintenApps"] = confspec
 
@@ -131,6 +132,10 @@ class WinTenAppsConfigDialog(wx.Dialog):
 		updateCheckButton = w10Helper.addItem(wx.Button(self, label=_("Check for add-on &update")))
 		updateCheckButton.Bind(wx.EVT_BUTTON, self.onUpdateCheck)
 
+		# Translators: A checbox to enable or disable sounds for suggestions.
+		self.suggestionSoundsCheckbox=w10Helper.addItem(wx.CheckBox(self,label=_("&Play sounds for search suggestions")))
+		self.suggestionSoundsCheckbox.SetValue(config.conf["wintenApps"]["suggestionSounds"])
+		
 		w10Helper.addDialogDismissButtons(self.CreateButtonSizer(wx.OK | wx.CANCEL))
 		self.Bind(wx.EVT_BUTTON, self.onOk, id=wx.ID_OK)
 		self.Bind(wx.EVT_BUTTON, self.onCancel, id=wx.ID_CANCEL)
@@ -154,6 +159,7 @@ class WinTenAppsConfigDialog(wx.Dialog):
 			whenToCheck = currentTime+(self.updateInterval.Value * addonUpdateCheckInterval)
 			updateChecker.Start(whenToCheck-currentTime, True)
 		config.conf["wintenApps"]["updateChannel"] = ("dev", "stable")[self.channels.GetSelection()]
+		config.conf["wintenApps"]["suggestionSounds"] = self.suggestionSoundsCheckbox.Value
 		self.Destroy()
 
 	def onCancel(self, evt):


### PR DESCRIPTION
When I am working in Notepad++ with autocompletion enabled the suggestion sound is distracting. I don't mind hearing the suggestions themselves, in fact they are helpful, but I need the sound effects to be disabled in this case.

I would have removed the wave files and called it done, but I like the suggestion sounds on the start screen and in other search boxes.