### PR TITLE
Logical simplification: Remove else since after if is a return sentence

### DIFF
--- a/addon/appModules/calculator.py
+++ b/addon/appModules/calculator.py
@@ -17,8 +17,7 @@ class CalculatorResult(UIA):
 	def event_nameChange(self):
 		if not self.appModule.shouldAnnounceResult:
 			return
-		else:
-			self.appModule.shouldAnnounceResult = False
+		self.appModule.shouldAnnounceResult = False
 
 
 class AppModule(appModuleHandler.AppModule):


### PR DESCRIPTION
Also, could be use getChild(index) instead of children[index]